### PR TITLE
fix: add Spotless/ktfmt formatter and fix broken make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	./gradlew detekt
 
 format:
-	./gradlew formatKotlin
+	./gradlew spotlessApply
 
 check: format lint test build
 	@echo "All checks passed."

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,58 +1,68 @@
 plugins {
-    kotlin("jvm") version "2.3.20"
-    kotlin("plugin.allopen") version "2.3.20"
-    id("io.quarkus") version "3.34.1"
-    id("io.gitlab.arturbosch.detekt") version "1.23.8"
+  kotlin("jvm") version "2.3.20"
+  kotlin("plugin.allopen") version "2.3.20"
+  id("io.quarkus") version "3.34.1"
+  id("io.gitlab.arturbosch.detekt") version "1.23.8"
+  id("com.diffplug.spotless") version "7.0.3"
 }
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
 val quarkusPlatformGroupId: String by project
 val quarkusPlatformArtifactId: String by project
 val quarkusPlatformVersion: String by project
 
 dependencies {
-    implementation(enforcedPlatform("$quarkusPlatformGroupId:$quarkusPlatformArtifactId:$quarkusPlatformVersion"))
-    implementation("io.quarkus:quarkus-kotlin")
-    implementation("io.quarkus:quarkus-arc")
-    implementation("io.quarkus:quarkus-grpc")
-    implementation("io.quarkus:quarkus-jdbc-postgresql")
-    implementation("io.quarkus:quarkus-hibernate-orm-panache-kotlin")
-    implementation("io.quarkus:quarkus-flyway")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("com.google.protobuf:protobuf-kotlin:4.29.3")
+  implementation(
+      enforcedPlatform(
+          "$quarkusPlatformGroupId:$quarkusPlatformArtifactId:$quarkusPlatformVersion"))
+  implementation("io.quarkus:quarkus-kotlin")
+  implementation("io.quarkus:quarkus-arc")
+  implementation("io.quarkus:quarkus-grpc")
+  implementation("io.quarkus:quarkus-jdbc-postgresql")
+  implementation("io.quarkus:quarkus-hibernate-orm-panache-kotlin")
+  implementation("io.quarkus:quarkus-flyway")
+  implementation("org.jetbrains.kotlin:kotlin-stdlib")
+  implementation("com.google.protobuf:protobuf-kotlin:4.29.3")
 
-    testImplementation("io.quarkus:quarkus-junit5")
-    testImplementation("io.quarkus:quarkus-jdbc-h2")
-    testImplementation("io.rest-assured:rest-assured")
+  testImplementation("io.quarkus:quarkus-junit5")
+  testImplementation("io.quarkus:quarkus-jdbc-h2")
+  testImplementation("io.rest-assured:rest-assured")
 }
 
 group = "com.akaitigo"
+
 version = "0.0.1"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+  sourceCompatibility = JavaVersion.VERSION_21
+  targetCompatibility = JavaVersion.VERSION_21
 }
 
 kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-        javaParameters.set(true)
-    }
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    javaParameters.set(true)
+  }
 }
 
 allOpen {
-    annotation("jakarta.ws.rs.Path")
-    annotation("jakarta.enterprise.context.ApplicationScoped")
-    annotation("jakarta.persistence.Entity")
-    annotation("io.quarkus.test.junit.QuarkusTest")
+  annotation("jakarta.ws.rs.Path")
+  annotation("jakarta.enterprise.context.ApplicationScoped")
+  annotation("jakarta.persistence.Entity")
+  annotation("io.quarkus.test.junit.QuarkusTest")
 }
 
 detekt {
-    config.setFrom("$projectDir/detekt.yml")
-    parallel = true
-    buildUponDefaultConfig = true
+  config.setFrom("$projectDir/detekt.yml")
+  parallel = true
+  buildUponDefaultConfig = true
+}
+
+spotless {
+  kotlin {
+    target("src/**/*.kt")
+    ktfmt()
+  }
+  kotlinGradle { ktfmt() }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,12 +1,10 @@
 pluginManagement {
-    val quarkusPluginVersion: String by settings
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    plugins {
-        id("io.quarkus") version quarkusPluginVersion
-    }
+  val quarkusPluginVersion: String by settings
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+  plugins { id("io.quarkus") version quarkusPluginVersion }
 }
 
 rootProject.name = "label-decode-api"

--- a/src/main/kotlin/com/akaitigo/labeldecode/grpc/LabelDecodeGrpcService.kt
+++ b/src/main/kotlin/com/akaitigo/labeldecode/grpc/LabelDecodeGrpcService.kt
@@ -19,153 +19,133 @@ private const val MAX_RAW_TEXT_LENGTH = 10_000
 class LabelDecodeGrpcService(
     private val parser: LabelParser,
 ) : LabelDecodeServiceGrpc.LabelDecodeServiceImplBase() {
-    override fun parseLabel(
-        request: ParseLabelRequest,
-        responseObserver: StreamObserver<ParseLabelResponse>,
-    ) {
-        val rawText = validateRawText(request.rawText, responseObserver) ?: return
+  override fun parseLabel(
+      request: ParseLabelRequest,
+      responseObserver: StreamObserver<ParseLabelResponse>,
+  ) {
+    val rawText = validateRawText(request.rawText, responseObserver) ?: return
 
-        val parsed = parser.parse(rawText)
+    val parsed = parser.parse(rawText)
 
-        val protoIngredients =
-            parsed.ingredients.map { ingredient ->
-                akaitigo.labeldecode.v1.Ingredient
-                    .newBuilder()
-                    .setName(ingredient.name)
-                    .addAllAllergenSources(ingredient.allergenSources)
-                    .build()
-            }
-
-        val protoAdditives =
-            parsed.additives.map { additive ->
-                akaitigo.labeldecode.v1.Additive
-                    .newBuilder()
-                    .setName(additive.name)
-                    .setCategory(additive.category)
-                    .build()
-            }
-
-        val protoAllergens =
-            parsed.allergens.map { allergen ->
-                akaitigo.labeldecode.v1.Allergen
-                    .newBuilder()
-                    .setName(allergen.name)
-                    .setType(mapAllergenType(allergen.type))
-                    .setSourceText(allergen.sourceText)
-                    .build()
-            }
-
-        val label =
-            akaitigo.labeldecode.v1.ParsedLabel
-                .newBuilder()
-                .addAllIngredients(protoIngredients)
-                .addAllAdditives(protoAdditives)
-                .addAllAllergens(protoAllergens)
-                .setOriginalText(parsed.originalText)
-                .build()
-
-        val response =
-            ParseLabelResponse
-                .newBuilder()
-                .setLabel(label)
-                .build()
-
-        responseObserver.onNext(response)
-        responseObserver.onCompleted()
-    }
-
-    override fun detectAllergens(
-        request: DetectAllergensRequest,
-        responseObserver: StreamObserver<DetectAllergensResponse>,
-    ) {
-        val rawText = validateRawText(request.rawText, responseObserver) ?: return
-
-        val allergens = parser.detectAllergens(rawText)
-
-        val protoAllergens =
-            allergens.map { allergen ->
-                akaitigo.labeldecode.v1.Allergen
-                    .newBuilder()
-                    .setName(allergen.name)
-                    .setType(mapAllergenType(allergen.type))
-                    .setSourceText(allergen.sourceText)
-                    .build()
-            }
-
-        val response =
-            DetectAllergensResponse
-                .newBuilder()
-                .addAllAllergens(protoAllergens)
-                .build()
-
-        responseObserver.onNext(response)
-        responseObserver.onCompleted()
-    }
-
-    override fun classifyAdditives(
-        request: ClassifyAdditivesRequest,
-        responseObserver: StreamObserver<ClassifyAdditivesResponse>,
-    ) {
-        val rawText = validateRawText(request.rawText, responseObserver) ?: return
-
-        val additives = parser.parseAdditivesFromFullText(rawText)
-
-        val protoAdditives =
-            additives.map { additive ->
-                akaitigo.labeldecode.v1.Additive
-                    .newBuilder()
-                    .setName(additive.name)
-                    .setCategory(additive.category)
-                    .build()
-            }
-
-        val response =
-            ClassifyAdditivesResponse
-                .newBuilder()
-                .addAllAdditives(protoAdditives)
-                .build()
-
-        responseObserver.onNext(response)
-        responseObserver.onCompleted()
-    }
-
-    private fun <T> validateRawText(
-        rawText: String,
-        responseObserver: StreamObserver<T>,
-    ): String? {
-        val error =
-            when {
-                rawText.isBlank() -> {
-                    "raw_text must not be empty"
-                }
-
-                rawText.length > MAX_RAW_TEXT_LENGTH -> {
-                    "raw_text exceeds maximum length of $MAX_RAW_TEXT_LENGTH"
-                }
-
-                else -> {
-                    null
-                }
-            }
-        if (error != null) {
-            responseObserver.onError(
-                Status.INVALID_ARGUMENT
-                    .withDescription(error)
-                    .asRuntimeException(),
-            )
-            return null
+    val protoIngredients =
+        parsed.ingredients.map { ingredient ->
+          akaitigo.labeldecode.v1.Ingredient.newBuilder()
+              .setName(ingredient.name)
+              .addAllAllergenSources(ingredient.allergenSources)
+              .build()
         }
-        return rawText
-    }
 
-    private fun mapAllergenType(type: AllergenType): akaitigo.labeldecode.v1.AllergenType =
-        when (type) {
-            AllergenType.MANDATORY -> {
-                akaitigo.labeldecode.v1.AllergenType.ALLERGEN_TYPE_MANDATORY
-            }
-
-            AllergenType.RECOMMENDED -> {
-                akaitigo.labeldecode.v1.AllergenType.ALLERGEN_TYPE_RECOMMENDED
-            }
+    val protoAdditives =
+        parsed.additives.map { additive ->
+          akaitigo.labeldecode.v1.Additive.newBuilder()
+              .setName(additive.name)
+              .setCategory(additive.category)
+              .build()
         }
+
+    val protoAllergens =
+        parsed.allergens.map { allergen ->
+          akaitigo.labeldecode.v1.Allergen.newBuilder()
+              .setName(allergen.name)
+              .setType(mapAllergenType(allergen.type))
+              .setSourceText(allergen.sourceText)
+              .build()
+        }
+
+    val label =
+        akaitigo.labeldecode.v1.ParsedLabel.newBuilder()
+            .addAllIngredients(protoIngredients)
+            .addAllAdditives(protoAdditives)
+            .addAllAllergens(protoAllergens)
+            .setOriginalText(parsed.originalText)
+            .build()
+
+    val response = ParseLabelResponse.newBuilder().setLabel(label).build()
+
+    responseObserver.onNext(response)
+    responseObserver.onCompleted()
+  }
+
+  override fun detectAllergens(
+      request: DetectAllergensRequest,
+      responseObserver: StreamObserver<DetectAllergensResponse>,
+  ) {
+    val rawText = validateRawText(request.rawText, responseObserver) ?: return
+
+    val allergens = parser.detectAllergens(rawText)
+
+    val protoAllergens =
+        allergens.map { allergen ->
+          akaitigo.labeldecode.v1.Allergen.newBuilder()
+              .setName(allergen.name)
+              .setType(mapAllergenType(allergen.type))
+              .setSourceText(allergen.sourceText)
+              .build()
+        }
+
+    val response = DetectAllergensResponse.newBuilder().addAllAllergens(protoAllergens).build()
+
+    responseObserver.onNext(response)
+    responseObserver.onCompleted()
+  }
+
+  override fun classifyAdditives(
+      request: ClassifyAdditivesRequest,
+      responseObserver: StreamObserver<ClassifyAdditivesResponse>,
+  ) {
+    val rawText = validateRawText(request.rawText, responseObserver) ?: return
+
+    val additives = parser.parseAdditivesFromFullText(rawText)
+
+    val protoAdditives =
+        additives.map { additive ->
+          akaitigo.labeldecode.v1.Additive.newBuilder()
+              .setName(additive.name)
+              .setCategory(additive.category)
+              .build()
+        }
+
+    val response = ClassifyAdditivesResponse.newBuilder().addAllAdditives(protoAdditives).build()
+
+    responseObserver.onNext(response)
+    responseObserver.onCompleted()
+  }
+
+  private fun <T> validateRawText(
+      rawText: String,
+      responseObserver: StreamObserver<T>,
+  ): String? {
+    val error =
+        when {
+          rawText.isBlank() -> {
+            "raw_text must not be empty"
+          }
+
+          rawText.length > MAX_RAW_TEXT_LENGTH -> {
+            "raw_text exceeds maximum length of $MAX_RAW_TEXT_LENGTH"
+          }
+
+          else -> {
+            null
+          }
+        }
+    if (error != null) {
+      responseObserver.onError(
+          Status.INVALID_ARGUMENT.withDescription(error).asRuntimeException(),
+      )
+      return null
+    }
+    return rawText
+  }
+
+  private fun mapAllergenType(type: AllergenType): akaitigo.labeldecode.v1.AllergenType =
+      when (type) {
+        AllergenType.MANDATORY -> {
+          akaitigo.labeldecode.v1.AllergenType.ALLERGEN_TYPE_MANDATORY
+        }
+
+        AllergenType.RECOMMENDED -> {
+          akaitigo.labeldecode.v1.AllergenType.ALLERGEN_TYPE_RECOMMENDED
+        }
+      }
 }

--- a/src/main/kotlin/com/akaitigo/labeldecode/model/Allergen.kt
+++ b/src/main/kotlin/com/akaitigo/labeldecode/model/Allergen.kt
@@ -7,6 +7,6 @@ data class Allergen(
 )
 
 enum class AllergenType {
-    MANDATORY,
-    RECOMMENDED,
+  MANDATORY,
+  RECOMMENDED,
 }

--- a/src/main/kotlin/com/akaitigo/labeldecode/parser/LabelParser.kt
+++ b/src/main/kotlin/com/akaitigo/labeldecode/parser/LabelParser.kt
@@ -14,12 +14,10 @@ private val ITEM_SEPARATOR = Regex("[、,，]")
 
 private val ADDITIVE_CATEGORY_PATTERN =
     Regex(
-        "[（(](保存料|着色料|甘味料|酸化防止剤|乳化剤|増粘剤|膨張剤|調味料|酸味料|" +
-            "pH調整剤|香料|発色剤|漂白剤|防かび剤|栄養強化剤|安定剤|ゲル化剤)[）)]",
+        "[（(](保存料|着色料|甘味料|酸化防止剤|乳化剤|増粘剤|膨張剤|調味料|酸味料|" + "pH調整剤|香料|発色剤|漂白剤|防かび剤|栄養強化剤|安定剤|ゲル化剤)[）)]",
     )
 
-private val MANDATORY_ALLERGENS =
-    setOf("えび", "かに", "くるみ", "小麦", "そば", "卵", "乳", "落花生")
+private val MANDATORY_ALLERGENS = setOf("えび", "かに", "くるみ", "小麦", "そば", "卵", "乳", "落花生")
 
 private val RECOMMENDED_ALLERGENS =
     setOf(
@@ -59,123 +57,115 @@ private val ALLERGEN_FALSE_POSITIVES =
 class LabelParser(
     private val additiveLookup: AdditiveLookup,
 ) {
-    fun parse(rawText: String): ParsedLabel {
-        val parts = SLASH_PATTERN.split(rawText, limit = 2)
-        val ingredientsPart = parts[0].trim()
-        val additivesPart =
-            if (parts.size > 1) {
-                parts[1].trim()
-            } else {
-                ""
-            }
+  fun parse(rawText: String): ParsedLabel {
+    val parts = SLASH_PATTERN.split(rawText, limit = 2)
+    val ingredientsPart = parts[0].trim()
+    val additivesPart =
+        if (parts.size > 1) {
+          parts[1].trim()
+        } else {
+          ""
+        }
 
-        val ingredients = parseIngredients(ingredientsPart)
-        val additives = parseAdditives(additivesPart)
-        val allergens = findAllAllergens(rawText)
+    val ingredients = parseIngredients(ingredientsPart)
+    val additives = parseAdditives(additivesPart)
+    val allergens = findAllAllergens(rawText)
 
-        return ParsedLabel(
-            ingredients = ingredients,
-            additives = additives,
-            allergens = allergens,
-            originalText = rawText,
+    return ParsedLabel(
+        ingredients = ingredients,
+        additives = additives,
+        allergens = allergens,
+        originalText = rawText,
+    )
+  }
+
+  fun parseIngredients(text: String): List<Ingredient> {
+    if (text.isBlank()) {
+      return emptyList()
+    }
+    return splitItems(text).map { item ->
+      val allergenSources =
+          extractParenContent(item).flatMap { content -> findAllAllergens(content) }.map { it.name }
+      val name = item.replace(PAREN_PATTERN, "").trim()
+      Ingredient(name = name, allergenSources = allergenSources)
+    }
+  }
+
+  fun parseAdditives(text: String): List<Additive> {
+    if (text.isBlank()) {
+      return emptyList()
+    }
+    return splitItems(text).map { item ->
+      val name = item.replace(ADDITIVE_CATEGORY_PATTERN, "").trim()
+      val category = resolveAdditiveCategory(item, name)
+      Additive(name = name, category = category)
+    }
+  }
+
+  fun detectAllergens(text: String): List<Allergen> = findAllAllergens(text)
+
+  fun parseAdditivesFromFullText(rawText: String): List<Additive> {
+    val parts = SLASH_PATTERN.split(rawText, limit = 2)
+    val additivesPart =
+        if (parts.size > 1) {
+          parts[1].trim()
+        } else {
+          ""
+        }
+    return parseAdditives(additivesPart)
+  }
+
+  private fun resolveAdditiveCategory(
+      rawItem: String,
+      name: String,
+  ): String =
+      ADDITIVE_CATEGORY_PATTERN.find(rawItem)?.groupValues?.get(1)
+          ?: additiveLookup.findCategoryByName(name)
+          ?: additiveLookup.findCategoryByPartialName(name)
+          ?: "その他"
+
+  private fun findAllAllergens(text: String): List<Allergen> {
+    val found = mutableListOf<Allergen>()
+    for (allergen in MANDATORY_ALLERGENS) {
+      if (matchesAllergen(text, allergen)) {
+        found.add(
+            Allergen(
+                name = allergen,
+                type = AllergenType.MANDATORY,
+                sourceText = allergen,
+            ),
         )
+      }
     }
-
-    fun parseIngredients(text: String): List<Ingredient> {
-        if (text.isBlank()) {
-            return emptyList()
-        }
-        return splitItems(text).map { item ->
-            val allergenSources =
-                extractParenContent(item)
-                    .flatMap { content -> findAllAllergens(content) }
-                    .map { it.name }
-            val name = item.replace(PAREN_PATTERN, "").trim()
-            Ingredient(name = name, allergenSources = allergenSources)
-        }
+    for (allergen in RECOMMENDED_ALLERGENS) {
+      if (matchesAllergen(text, allergen)) {
+        found.add(
+            Allergen(
+                name = allergen,
+                type = AllergenType.RECOMMENDED,
+                sourceText = allergen,
+            ),
+        )
+      }
     }
+    return found
+  }
 
-    fun parseAdditives(text: String): List<Additive> {
-        if (text.isBlank()) {
-            return emptyList()
-        }
-        return splitItems(text).map { item ->
-            val name = item.replace(ADDITIVE_CATEGORY_PATTERN, "").trim()
-            val category = resolveAdditiveCategory(item, name)
-            Additive(name = name, category = category)
-        }
+  private fun matchesAllergen(
+      text: String,
+      allergen: String,
+  ): Boolean {
+    if (!text.contains(allergen)) {
+      return false
     }
-
-    fun detectAllergens(text: String): List<Allergen> = findAllAllergens(text)
-
-    fun parseAdditivesFromFullText(rawText: String): List<Additive> {
-        val parts = SLASH_PATTERN.split(rawText, limit = 2)
-        val additivesPart =
-            if (parts.size > 1) {
-                parts[1].trim()
-            } else {
-                ""
-            }
-        return parseAdditives(additivesPart)
-    }
-
-    private fun resolveAdditiveCategory(
-        rawItem: String,
-        name: String,
-    ): String =
-        ADDITIVE_CATEGORY_PATTERN.find(rawItem)?.groupValues?.get(1)
-            ?: additiveLookup.findCategoryByName(name)
-            ?: additiveLookup.findCategoryByPartialName(name)
-            ?: "その他"
-
-    private fun findAllAllergens(text: String): List<Allergen> {
-        val found = mutableListOf<Allergen>()
-        for (allergen in MANDATORY_ALLERGENS) {
-            if (matchesAllergen(text, allergen)) {
-                found.add(
-                    Allergen(
-                        name = allergen,
-                        type = AllergenType.MANDATORY,
-                        sourceText = allergen,
-                    ),
-                )
-            }
-        }
-        for (allergen in RECOMMENDED_ALLERGENS) {
-            if (matchesAllergen(text, allergen)) {
-                found.add(
-                    Allergen(
-                        name = allergen,
-                        type = AllergenType.RECOMMENDED,
-                        sourceText = allergen,
-                    ),
-                )
-            }
-        }
-        return found
-    }
-
-    private fun matchesAllergen(
-        text: String,
-        allergen: String,
-    ): Boolean {
-        if (!text.contains(allergen)) {
-            return false
-        }
-        val falsePositives = ALLERGEN_FALSE_POSITIVES[allergen]
-        val cleaned = falsePositives?.fold(text) { acc, fp -> acc.replace(fp, "") } ?: text
-        return cleaned.contains(allergen)
-    }
+    val falsePositives = ALLERGEN_FALSE_POSITIVES[allergen]
+    val cleaned = falsePositives?.fold(text) { acc, fp -> acc.replace(fp, "") } ?: text
+    return cleaned.contains(allergen)
+  }
 }
 
 private fun splitItems(text: String): List<String> =
-    ITEM_SEPARATOR
-        .split(text)
-        .map { it.trim() }
-        .filter { it.isNotEmpty() }
+    ITEM_SEPARATOR.split(text).map { it.trim() }.filter { it.isNotEmpty() }
 
 private fun extractParenContent(text: String): List<String> =
-    PAREN_PATTERN
-        .findAll(text)
-        .map { it.groupValues[1] }
-        .toList()
+    PAREN_PATTERN.findAll(text).map { it.groupValues[1] }.toList()

--- a/src/main/kotlin/com/akaitigo/labeldecode/repository/AdditiveLookup.kt
+++ b/src/main/kotlin/com/akaitigo/labeldecode/repository/AdditiveLookup.kt
@@ -1,7 +1,7 @@
 package com.akaitigo.labeldecode.repository
 
 interface AdditiveLookup {
-    fun findCategoryByName(name: String): String?
+  fun findCategoryByName(name: String): String?
 
-    fun findCategoryByPartialName(name: String): String?
+  fun findCategoryByPartialName(name: String): String?
 }

--- a/src/main/kotlin/com/akaitigo/labeldecode/repository/AdditiveMasterRepository.kt
+++ b/src/main/kotlin/com/akaitigo/labeldecode/repository/AdditiveMasterRepository.kt
@@ -7,34 +7,34 @@ import javax.sql.DataSource
 class AdditiveMasterRepository(
     private val dataSource: DataSource,
 ) : AdditiveLookup {
-    override fun findCategoryByName(name: String): String? =
-        executeQuery(
-            "SELECT category FROM additive_master WHERE name = ?",
-            name,
-        )
+  override fun findCategoryByName(name: String): String? =
+      executeQuery(
+          "SELECT category FROM additive_master WHERE name = ?",
+          name,
+      )
 
-    override fun findCategoryByPartialName(name: String): String? =
-        executeQuery(
-            "SELECT category FROM additive_master " +
-                "WHERE ? LIKE '%' || name || '%' " +
-                "ORDER BY LENGTH(name) DESC LIMIT 1",
-            name,
-        )
+  override fun findCategoryByPartialName(name: String): String? =
+      executeQuery(
+          "SELECT category FROM additive_master " +
+              "WHERE ? LIKE '%' || name || '%' " +
+              "ORDER BY LENGTH(name) DESC LIMIT 1",
+          name,
+      )
 
-    private fun executeQuery(
-        sql: String,
-        param: String,
-    ): String? =
-        dataSource.connection.use { conn ->
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, param)
-                stmt.executeQuery().use { rs ->
-                    if (rs.next()) {
-                        rs.getString("category")
-                    } else {
-                        null
-                    }
-                }
+  private fun executeQuery(
+      sql: String,
+      param: String,
+  ): String? =
+      dataSource.connection.use { conn ->
+        conn.prepareStatement(sql).use { stmt ->
+          stmt.setString(1, param)
+          stmt.executeQuery().use { rs ->
+            if (rs.next()) {
+              rs.getString("category")
+            } else {
+              null
             }
+          }
         }
+      }
 }

--- a/src/test/kotlin/com/akaitigo/labeldecode/grpc/LabelDecodeGrpcServiceTest.kt
+++ b/src/test/kotlin/com/akaitigo/labeldecode/grpc/LabelDecodeGrpcServiceTest.kt
@@ -15,105 +15,74 @@ import org.junit.jupiter.api.assertThrows
 
 @QuarkusTest
 class LabelDecodeGrpcServiceTest {
-    @GrpcClient("labeldecode")
-    lateinit var client: LabelDecodeServiceGrpc.LabelDecodeServiceBlockingStub
+  @GrpcClient("labeldecode")
+  lateinit var client: LabelDecodeServiceGrpc.LabelDecodeServiceBlockingStub
 
-    @Test
-    fun `ParseLabel returns structured data for valid input`() {
-        val request =
-            ParseLabelRequest
-                .newBuilder()
-                .setRawText("小麦粉、砂糖、バター/ソルビン酸K（保存料）、カラメル色素")
-                .build()
+  @Test
+  fun `ParseLabel returns structured data for valid input`() {
+    val request = ParseLabelRequest.newBuilder().setRawText("小麦粉、砂糖、バター/ソルビン酸K（保存料）、カラメル色素").build()
 
-        val response = client.parseLabel(request)
+    val response = client.parseLabel(request)
 
-        assertNotNull(response.label)
-        assertEquals(3, response.label.ingredientsList.size)
-        assertEquals("小麦粉", response.label.ingredientsList[0].name)
-        assertEquals(2, response.label.additivesList.size)
-        assertEquals("ソルビン酸K", response.label.additivesList[0].name)
-        assertEquals("保存料", response.label.additivesList[0].category)
-        assertTrue(response.label.allergensList.any { it.name == "小麦" })
-    }
+    assertNotNull(response.label)
+    assertEquals(3, response.label.ingredientsList.size)
+    assertEquals("小麦粉", response.label.ingredientsList[0].name)
+    assertEquals(2, response.label.additivesList.size)
+    assertEquals("ソルビン酸K", response.label.additivesList[0].name)
+    assertEquals("保存料", response.label.additivesList[0].category)
+    assertTrue(response.label.allergensList.any { it.name == "小麦" })
+  }
 
-    @Test
-    fun `ParseLabel returns INVALID_ARGUMENT for empty input`() {
-        val request =
-            ParseLabelRequest
-                .newBuilder()
-                .setRawText("")
-                .build()
+  @Test
+  fun `ParseLabel returns INVALID_ARGUMENT for empty input`() {
+    val request = ParseLabelRequest.newBuilder().setRawText("").build()
 
-        val exception =
-            assertThrows<StatusRuntimeException> {
-                client.parseLabel(request)
-            }
+    val exception = assertThrows<StatusRuntimeException> { client.parseLabel(request) }
 
-        assertEquals("INVALID_ARGUMENT", exception.status.code.name)
-    }
+    assertEquals("INVALID_ARGUMENT", exception.status.code.name)
+  }
 
-    @Test
-    fun `DetectAllergens returns allergens for valid input`() {
-        val request =
-            DetectAllergensRequest
-                .newBuilder()
-                .setRawText("小麦粉（小麦を含む）、卵、乳製品、大豆（遺伝子組換えでない）")
-                .build()
+  @Test
+  fun `DetectAllergens returns allergens for valid input`() {
+    val request =
+        DetectAllergensRequest.newBuilder().setRawText("小麦粉（小麦を含む）、卵、乳製品、大豆（遺伝子組換えでない）").build()
 
-        val response = client.detectAllergens(request)
+    val response = client.detectAllergens(request)
 
-        val names = response.allergensList.map { it.name }
-        assertTrue(names.contains("小麦"))
-        assertTrue(names.contains("卵"))
-        assertTrue(names.contains("乳"))
-        assertTrue(names.contains("大豆"))
-    }
+    val names = response.allergensList.map { it.name }
+    assertTrue(names.contains("小麦"))
+    assertTrue(names.contains("卵"))
+    assertTrue(names.contains("乳"))
+    assertTrue(names.contains("大豆"))
+  }
 
-    @Test
-    fun `DetectAllergens returns INVALID_ARGUMENT for empty input`() {
-        val request =
-            DetectAllergensRequest
-                .newBuilder()
-                .setRawText("")
-                .build()
+  @Test
+  fun `DetectAllergens returns INVALID_ARGUMENT for empty input`() {
+    val request = DetectAllergensRequest.newBuilder().setRawText("").build()
 
-        val exception =
-            assertThrows<StatusRuntimeException> {
-                client.detectAllergens(request)
-            }
+    val exception = assertThrows<StatusRuntimeException> { client.detectAllergens(request) }
 
-        assertEquals("INVALID_ARGUMENT", exception.status.code.name)
-    }
+    assertEquals("INVALID_ARGUMENT", exception.status.code.name)
+  }
 
-    @Test
-    fun `ClassifyAdditives returns classified additives`() {
-        val request =
-            ClassifyAdditivesRequest
-                .newBuilder()
-                .setRawText("砂糖/ソルビン酸K（保存料）、アスパルテーム（甘味料）")
-                .build()
+  @Test
+  fun `ClassifyAdditives returns classified additives`() {
+    val request =
+        ClassifyAdditivesRequest.newBuilder().setRawText("砂糖/ソルビン酸K（保存料）、アスパルテーム（甘味料）").build()
 
-        val response = client.classifyAdditives(request)
+    val response = client.classifyAdditives(request)
 
-        assertEquals(2, response.additivesList.size)
-        assertEquals("保存料", response.additivesList[0].category)
-        assertEquals("甘味料", response.additivesList[1].category)
-    }
+    assertEquals(2, response.additivesList.size)
+    assertEquals("保存料", response.additivesList[0].category)
+    assertEquals("甘味料", response.additivesList[1].category)
+  }
 
-    @Test
-    fun `ClassifyAdditives returns INVALID_ARGUMENT for empty input`() {
-        val request =
-            ClassifyAdditivesRequest
-                .newBuilder()
-                .setRawText("")
-                .build()
+  @Test
+  fun `ClassifyAdditives returns INVALID_ARGUMENT for empty input`() {
+    val request = ClassifyAdditivesRequest.newBuilder().setRawText("").build()
 
-        val exception =
-            assertThrows<StatusRuntimeException> {
-                client.classifyAdditives(request)
-            }
+    val exception = assertThrows<StatusRuntimeException> { client.classifyAdditives(request) }
 
-        assertEquals("INVALID_ARGUMENT", exception.status.code.name)
-    }
+    assertEquals("INVALID_ARGUMENT", exception.status.code.name)
+  }
 }

--- a/src/test/kotlin/com/akaitigo/labeldecode/parser/AdditiveClassificationTest.kt
+++ b/src/test/kotlin/com/akaitigo/labeldecode/parser/AdditiveClassificationTest.kt
@@ -4,69 +4,69 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class AdditiveClassificationTest {
-    private val parser = LabelParser(StubAdditiveLookup())
+  private val parser = LabelParser(StubAdditiveLookup())
 
-    @Test
-    fun `classifies preservatives`() {
-        val result = parser.parseAdditives("ソルビン酸K（保存料）")
-        assertEquals(1, result.size)
-        assertEquals("ソルビン酸K", result[0].name)
-        assertEquals("保存料", result[0].category)
-    }
+  @Test
+  fun `classifies preservatives`() {
+    val result = parser.parseAdditives("ソルビン酸K（保存料）")
+    assertEquals(1, result.size)
+    assertEquals("ソルビン酸K", result[0].name)
+    assertEquals("保存料", result[0].category)
+  }
 
-    @Test
-    fun `classifies colorings`() {
-        val result = parser.parseAdditives("カラメル色素（着色料）")
-        assertEquals(1, result.size)
-        assertEquals("着色料", result[0].category)
-    }
+  @Test
+  fun `classifies colorings`() {
+    val result = parser.parseAdditives("カラメル色素（着色料）")
+    assertEquals(1, result.size)
+    assertEquals("着色料", result[0].category)
+  }
 
-    @Test
-    fun `classifies sweeteners`() {
-        val result = parser.parseAdditives("アスパルテーム（甘味料）")
-        assertEquals(1, result.size)
-        assertEquals("甘味料", result[0].category)
-    }
+  @Test
+  fun `classifies sweeteners`() {
+    val result = parser.parseAdditives("アスパルテーム（甘味料）")
+    assertEquals(1, result.size)
+    assertEquals("甘味料", result[0].category)
+  }
 
-    @Test
-    fun `classifies antioxidants`() {
-        val result = parser.parseAdditives("V.C（酸化防止剤）")
-        assertEquals(1, result.size)
-        assertEquals("酸化防止剤", result[0].category)
-    }
+  @Test
+  fun `classifies antioxidants`() {
+    val result = parser.parseAdditives("V.C（酸化防止剤）")
+    assertEquals(1, result.size)
+    assertEquals("酸化防止剤", result[0].category)
+  }
 
-    @Test
-    fun `classifies emulsifiers`() {
-        val result = parser.parseAdditives("レシチン（乳化剤）")
-        assertEquals(1, result.size)
-        assertEquals("乳化剤", result[0].category)
-    }
+  @Test
+  fun `classifies emulsifiers`() {
+    val result = parser.parseAdditives("レシチン（乳化剤）")
+    assertEquals(1, result.size)
+    assertEquals("乳化剤", result[0].category)
+  }
 
-    @Test
-    fun `classifies multiple additives`() {
-        val result =
-            parser.parseAdditives(
-                "ソルビン酸K（保存料）、アスパルテーム（甘味料）、V.C（酸化防止剤）、レシチン（乳化剤）、香料",
-            )
-        assertEquals(5, result.size)
-        assertEquals("保存料", result[0].category)
-        assertEquals("甘味料", result[1].category)
-        assertEquals("酸化防止剤", result[2].category)
-        assertEquals("乳化剤", result[3].category)
-        assertEquals("その他", result[4].category)
-    }
+  @Test
+  fun `classifies multiple additives`() {
+    val result =
+        parser.parseAdditives(
+            "ソルビン酸K（保存料）、アスパルテーム（甘味料）、V.C（酸化防止剤）、レシチン（乳化剤）、香料",
+        )
+    assertEquals(5, result.size)
+    assertEquals("保存料", result[0].category)
+    assertEquals("甘味料", result[1].category)
+    assertEquals("酸化防止剤", result[2].category)
+    assertEquals("乳化剤", result[3].category)
+    assertEquals("その他", result[4].category)
+  }
 
-    @Test
-    fun `handles half-width parentheses`() {
-        val result = parser.parseAdditives("ソルビン酸K(保存料)")
-        assertEquals(1, result.size)
-        assertEquals("保存料", result[0].category)
-    }
+  @Test
+  fun `handles half-width parentheses`() {
+    val result = parser.parseAdditives("ソルビン酸K(保存料)")
+    assertEquals(1, result.size)
+    assertEquals("保存料", result[0].category)
+  }
 
-    @Test
-    fun `additive without category returns その他`() {
-        val result = parser.parseAdditives("カラメル色素")
-        assertEquals(1, result.size)
-        assertEquals("その他", result[0].category)
-    }
+  @Test
+  fun `additive without category returns その他`() {
+    val result = parser.parseAdditives("カラメル色素")
+    assertEquals(1, result.size)
+    assertEquals("その他", result[0].category)
+  }
 }

--- a/src/test/kotlin/com/akaitigo/labeldecode/parser/AllergenDetectionTest.kt
+++ b/src/test/kotlin/com/akaitigo/labeldecode/parser/AllergenDetectionTest.kt
@@ -8,116 +8,129 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class AllergenDetectionTest {
-    private val parser = LabelParser(StubAdditiveLookup())
+  private val parser = LabelParser(StubAdditiveLookup())
 
-    @ParameterizedTest
-    @ValueSource(strings = ["えび", "かに", "くるみ", "小麦", "そば", "卵", "乳", "落花生"])
-    fun `detectAllergens finds all 8 mandatory allergens`(allergen: String) {
-        val result = parser.detectAllergens("この製品には${allergen}が含まれます")
-        assertTrue(result.any { it.name == allergen }) {
-            "Expected to detect mandatory allergen: $allergen"
-        }
-        assertEquals(AllergenType.MANDATORY, result.first { it.name == allergen }.type)
+  @ParameterizedTest
+  @ValueSource(strings = ["えび", "かに", "くるみ", "小麦", "そば", "卵", "乳", "落花生"])
+  fun `detectAllergens finds all 8 mandatory allergens`(allergen: String) {
+    val result = parser.detectAllergens("この製品には${allergen}が含まれます")
+    assertTrue(result.any { it.name == allergen }) {
+      "Expected to detect mandatory allergen: $allergen"
     }
+    assertEquals(AllergenType.MANDATORY, result.first { it.name == allergen }.type)
+  }
 
-    @ParameterizedTest
-    @ValueSource(
-        strings = [
-            "アーモンド", "あわび", "いか", "いくら", "オレンジ",
-            "カシューナッツ", "キウイフルーツ", "牛肉", "ごま",
-            "さけ", "さば", "大豆", "鶏肉", "バナナ", "豚肉",
-            "まつたけ", "もも", "やまいも", "りんご", "ゼラチン",
-        ],
-    )
-    fun `detectAllergens finds all 20 recommended allergens`(allergen: String) {
-        val result = parser.detectAllergens("この製品には${allergen}が含まれます")
-        assertTrue(result.any { it.name == allergen }) {
-            "Expected to detect recommended allergen: $allergen"
-        }
-        assertEquals(AllergenType.RECOMMENDED, result.first { it.name == allergen }.type)
+  @ParameterizedTest
+  @ValueSource(
+      strings =
+          [
+              "アーモンド",
+              "あわび",
+              "いか",
+              "いくら",
+              "オレンジ",
+              "カシューナッツ",
+              "キウイフルーツ",
+              "牛肉",
+              "ごま",
+              "さけ",
+              "さば",
+              "大豆",
+              "鶏肉",
+              "バナナ",
+              "豚肉",
+              "まつたけ",
+              "もも",
+              "やまいも",
+              "りんご",
+              "ゼラチン",
+          ],
+  )
+  fun `detectAllergens finds all 20 recommended allergens`(allergen: String) {
+    val result = parser.detectAllergens("この製品には${allergen}が含まれます")
+    assertTrue(result.any { it.name == allergen }) {
+      "Expected to detect recommended allergen: $allergen"
     }
+    assertEquals(AllergenType.RECOMMENDED, result.first { it.name == allergen }.type)
+  }
 
-    @Test
-    fun `detectAllergens returns empty for text without allergens`() {
-        val result = parser.detectAllergens("水、食塩、砂糖")
-        assertTrue(result.isEmpty())
+  @Test
+  fun `detectAllergens returns empty for text without allergens`() {
+    val result = parser.detectAllergens("水、食塩、砂糖")
+    assertTrue(result.isEmpty())
+  }
+
+  @Test
+  fun `detectAllergens handles mixed mandatory and recommended`() {
+    val result = parser.detectAllergens("小麦粉、大豆（遺伝子組換えでない）、卵黄、りんご果汁")
+    val mandatoryNames = result.filter { it.type == AllergenType.MANDATORY }.map { it.name }
+    val recommendedNames = result.filter { it.type == AllergenType.RECOMMENDED }.map { it.name }
+
+    assertTrue(mandatoryNames.contains("小麦"))
+    assertTrue(mandatoryNames.contains("卵"))
+    assertTrue(recommendedNames.contains("大豆"))
+    assertTrue(recommendedNames.contains("りんご"))
+  }
+
+  @Test
+  fun `false positive - 大豆油 does not trigger 大豆 allergen`() {
+    val result = parser.detectAllergens("大豆油、砂糖")
+    assertTrue(result.none { it.name == "大豆" })
+  }
+
+  @Test
+  fun `false positive - 大豆レシチン does not trigger 大豆 allergen`() {
+    val result = parser.detectAllergens("大豆レシチン、食塩")
+    assertTrue(result.none { it.name == "大豆" })
+  }
+
+  @Test
+  fun `false positive - ごま油 does not trigger ごま allergen`() {
+    val result = parser.detectAllergens("ごま油、醤油")
+    assertTrue(result.none { it.name == "ごま" })
+  }
+
+  @Test
+  fun `false positive - 小麦でん粉 does not trigger 小麦 allergen`() {
+    val result = parser.detectAllergens("小麦でん粉、水")
+    assertTrue(result.none { it.name == "小麦" })
+  }
+
+  @Test
+  fun `false positive - もも色素 does not trigger もも allergen`() {
+    val result = parser.detectAllergens("もも色素、砂糖")
+    assertTrue(result.none { it.name == "もも" })
+  }
+
+  @Test
+  fun `false positive - 乳化剤 does not trigger 乳 allergen`() {
+    val result = parser.detectAllergens("乳化剤、香料")
+    assertTrue(result.none { it.name == "乳" })
+  }
+
+  @Test
+  fun `real allergen detected even when false positive text also present`() {
+    val result = parser.detectAllergens("大豆油、大豆（遺伝子組換えでない）")
+    assertTrue(result.any { it.name == "大豆" })
+  }
+
+  @Test
+  fun `multiple false positives together do not trigger allergen`() {
+    val result = parser.detectAllergens("植物油脂(大豆油)、乳化剤(大豆レシチン)")
+    assertTrue(result.none { it.name == "大豆" }) { "大豆油 + 大豆レシチン should not trigger 大豆 allergen" }
+  }
+
+  @Test
+  fun `multiple false positives with real allergen still detects`() {
+    val result = parser.detectAllergens("植物油脂(大豆油)、乳化剤(大豆レシチン)、大豆")
+    assertTrue(result.any { it.name == "大豆" }) {
+      "Real 大豆 should be detected even with false positive texts"
     }
+  }
 
-    @Test
-    fun `detectAllergens handles mixed mandatory and recommended`() {
-        val result = parser.detectAllergens("小麦粉、大豆（遺伝子組換えでない）、卵黄、りんご果汁")
-        val mandatoryNames = result.filter { it.type == AllergenType.MANDATORY }.map { it.name }
-        val recommendedNames = result.filter { it.type == AllergenType.RECOMMENDED }.map { it.name }
-
-        assertTrue(mandatoryNames.contains("小麦"))
-        assertTrue(mandatoryNames.contains("卵"))
-        assertTrue(recommendedNames.contains("大豆"))
-        assertTrue(recommendedNames.contains("りんご"))
-    }
-
-    @Test
-    fun `false positive - 大豆油 does not trigger 大豆 allergen`() {
-        val result = parser.detectAllergens("大豆油、砂糖")
-        assertTrue(result.none { it.name == "大豆" })
-    }
-
-    @Test
-    fun `false positive - 大豆レシチン does not trigger 大豆 allergen`() {
-        val result = parser.detectAllergens("大豆レシチン、食塩")
-        assertTrue(result.none { it.name == "大豆" })
-    }
-
-    @Test
-    fun `false positive - ごま油 does not trigger ごま allergen`() {
-        val result = parser.detectAllergens("ごま油、醤油")
-        assertTrue(result.none { it.name == "ごま" })
-    }
-
-    @Test
-    fun `false positive - 小麦でん粉 does not trigger 小麦 allergen`() {
-        val result = parser.detectAllergens("小麦でん粉、水")
-        assertTrue(result.none { it.name == "小麦" })
-    }
-
-    @Test
-    fun `false positive - もも色素 does not trigger もも allergen`() {
-        val result = parser.detectAllergens("もも色素、砂糖")
-        assertTrue(result.none { it.name == "もも" })
-    }
-
-    @Test
-    fun `false positive - 乳化剤 does not trigger 乳 allergen`() {
-        val result = parser.detectAllergens("乳化剤、香料")
-        assertTrue(result.none { it.name == "乳" })
-    }
-
-    @Test
-    fun `real allergen detected even when false positive text also present`() {
-        val result = parser.detectAllergens("大豆油、大豆（遺伝子組換えでない）")
-        assertTrue(result.any { it.name == "大豆" })
-    }
-
-    @Test
-    fun `multiple false positives together do not trigger allergen`() {
-        val result = parser.detectAllergens("植物油脂(大豆油)、乳化剤(大豆レシチン)")
-        assertTrue(result.none { it.name == "大豆" }) {
-            "大豆油 + 大豆レシチン should not trigger 大豆 allergen"
-        }
-    }
-
-    @Test
-    fun `multiple false positives with real allergen still detects`() {
-        val result = parser.detectAllergens("植物油脂(大豆油)、乳化剤(大豆レシチン)、大豆")
-        assertTrue(result.any { it.name == "大豆" }) {
-            "Real 大豆 should be detected even with false positive texts"
-        }
-    }
-
-    @Test
-    fun `false positive - 乳化剤 and 乳化 together do not trigger 乳 allergen`() {
-        val result = parser.detectAllergens("乳化剤(大豆レシチン)、グリセリン脂肪酸エステル(乳化)")
-        assertTrue(result.none { it.name == "乳" }) {
-            "乳化剤 + 乳化 should not trigger 乳 allergen"
-        }
-    }
+  @Test
+  fun `false positive - 乳化剤 and 乳化 together do not trigger 乳 allergen`() {
+    val result = parser.detectAllergens("乳化剤(大豆レシチン)、グリセリン脂肪酸エステル(乳化)")
+    assertTrue(result.none { it.name == "乳" }) { "乳化剤 + 乳化 should not trigger 乳 allergen" }
+  }
 }

--- a/src/test/kotlin/com/akaitigo/labeldecode/parser/DestructiveTest.kt
+++ b/src/test/kotlin/com/akaitigo/labeldecode/parser/DestructiveTest.kt
@@ -5,60 +5,60 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class DestructiveTest {
-    private val parser = LabelParser(StubAdditiveLookup())
+  private val parser = LabelParser(StubAdditiveLookup())
 
-    @Test
-    fun `empty string returns empty results`() {
-        val result = parser.parse("")
-        assertTrue(result.ingredients.isEmpty())
-        assertTrue(result.additives.isEmpty())
-        assertTrue(result.allergens.isEmpty())
-    }
+  @Test
+  fun `empty string returns empty results`() {
+    val result = parser.parse("")
+    assertTrue(result.ingredients.isEmpty())
+    assertTrue(result.additives.isEmpty())
+    assertTrue(result.allergens.isEmpty())
+  }
 
-    @Test
-    fun `slash only returns empty ingredients and additives`() {
-        val result = parser.parse("/")
-        assertTrue(result.ingredients.isEmpty())
-        assertTrue(result.additives.isEmpty())
-    }
+  @Test
+  fun `slash only returns empty ingredients and additives`() {
+    val result = parser.parse("/")
+    assertTrue(result.ingredients.isEmpty())
+    assertTrue(result.additives.isEmpty())
+  }
 
-    @Test
-    fun `very long input does not crash`() {
-        val longText = "小麦粉、".repeat(10000) + "砂糖/ソルビン酸K（保存料）"
-        val result = parser.parse(longText)
-        assertTrue(result.ingredients.size > 1)
-        assertEquals(1, result.additives.size)
-    }
+  @Test
+  fun `very long input does not crash`() {
+    val longText = "小麦粉、".repeat(10000) + "砂糖/ソルビン酸K（保存料）"
+    val result = parser.parse(longText)
+    assertTrue(result.ingredients.size > 1)
+    assertEquals(1, result.additives.size)
+  }
 
-    @Test
-    fun `special characters in input do not cause errors`() {
-        val result = parser.parse("原材料&lt;script&gt;、砂糖/添加物")
-        assertEquals(2, result.ingredients.size)
-        assertEquals(1, result.additives.size)
-    }
+  @Test
+  fun `special characters in input do not cause errors`() {
+    val result = parser.parse("原材料&lt;script&gt;、砂糖/添加物")
+    assertEquals(2, result.ingredients.size)
+    assertEquals(1, result.additives.size)
+  }
 
-    @Test
-    fun `SQL injection in input does not cause errors`() {
-        val result = parser.parse("原材料'; DROP TABLE additive_master; --、砂糖")
-        assertEquals(2, result.ingredients.size)
-    }
+  @Test
+  fun `SQL injection in input does not cause errors`() {
+    val result = parser.parse("原材料'; DROP TABLE additive_master; --、砂糖")
+    assertEquals(2, result.ingredients.size)
+  }
 
-    @Test
-    fun `unicode edge cases`() {
-        val result = parser.parse("𠮷野家の牛丼/調味料（アミノ酸等）")
-        assertEquals(1, result.ingredients.size)
-        assertEquals(1, result.additives.size)
-    }
+  @Test
+  fun `unicode edge cases`() {
+    val result = parser.parse("𠮷野家の牛丼/調味料（アミノ酸等）")
+    assertEquals(1, result.ingredients.size)
+    assertEquals(1, result.additives.size)
+  }
 
-    @Test
-    fun `multiple consecutive slashes`() {
-        val result = parser.parse("小麦粉//ソルビン酸K（保存料）")
-        assertTrue(result.ingredients.isNotEmpty())
-    }
+  @Test
+  fun `multiple consecutive slashes`() {
+    val result = parser.parse("小麦粉//ソルビン酸K（保存料）")
+    assertTrue(result.ingredients.isNotEmpty())
+  }
 
-    @Test
-    fun `only allergens no ingredients`() {
-        val allergens = parser.detectAllergens("")
-        assertTrue(allergens.isEmpty())
-    }
+  @Test
+  fun `only allergens no ingredients`() {
+    val allergens = parser.detectAllergens("")
+    assertTrue(allergens.isEmpty())
+  }
 }

--- a/src/test/kotlin/com/akaitigo/labeldecode/parser/LabelParserTest.kt
+++ b/src/test/kotlin/com/akaitigo/labeldecode/parser/LabelParserTest.kt
@@ -6,112 +6,110 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class LabelParserTest {
-    private val parser = LabelParser(StubAdditiveLookup())
+  private val parser = LabelParser(StubAdditiveLookup())
 
-    @Test
-    fun `parse splits ingredients and additives by slash`() {
-        val result = parser.parse("小麦粉、砂糖、バター/ソルビン酸K（保存料）、カラメル色素")
+  @Test
+  fun `parse splits ingredients and additives by slash`() {
+    val result = parser.parse("小麦粉、砂糖、バター/ソルビン酸K（保存料）、カラメル色素")
 
-        assertEquals(3, result.ingredients.size)
-        assertEquals("小麦粉", result.ingredients[0].name)
-        assertEquals("砂糖", result.ingredients[1].name)
-        assertEquals("バター", result.ingredients[2].name)
+    assertEquals(3, result.ingredients.size)
+    assertEquals("小麦粉", result.ingredients[0].name)
+    assertEquals("砂糖", result.ingredients[1].name)
+    assertEquals("バター", result.ingredients[2].name)
 
-        assertEquals(2, result.additives.size)
-        assertEquals("ソルビン酸K", result.additives[0].name)
-        assertEquals("保存料", result.additives[0].category)
-        assertEquals("カラメル色素", result.additives[1].name)
-    }
+    assertEquals(2, result.additives.size)
+    assertEquals("ソルビン酸K", result.additives[0].name)
+    assertEquals("保存料", result.additives[0].category)
+    assertEquals("カラメル色素", result.additives[1].name)
+  }
 
-    @Test
-    fun `parse handles full-width slash`() {
-        val result = parser.parse("小麦粉、砂糖／ソルビン酸K（保存料）")
+  @Test
+  fun `parse handles full-width slash`() {
+    val result = parser.parse("小麦粉、砂糖／ソルビン酸K（保存料）")
 
-        assertEquals(2, result.ingredients.size)
-        assertEquals(1, result.additives.size)
-    }
+    assertEquals(2, result.ingredients.size)
+    assertEquals(1, result.additives.size)
+  }
 
-    @Test
-    fun `parse with no additives section`() {
-        val result = parser.parse("小麦粉、砂糖、バター")
+  @Test
+  fun `parse with no additives section`() {
+    val result = parser.parse("小麦粉、砂糖、バター")
 
-        assertEquals(3, result.ingredients.size)
-        assertTrue(result.additives.isEmpty())
-    }
+    assertEquals(3, result.ingredients.size)
+    assertTrue(result.additives.isEmpty())
+  }
 
-    @Test
-    fun `detectAllergens finds mandatory allergens`() {
-        val result = parser.detectAllergens("小麦粉（小麦を含む）、卵、乳製品")
+  @Test
+  fun `detectAllergens finds mandatory allergens`() {
+    val result = parser.detectAllergens("小麦粉（小麦を含む）、卵、乳製品")
 
-        val names = result.map { it.name }
-        assertTrue(names.contains("小麦"))
-        assertTrue(names.contains("卵"))
-        assertTrue(names.contains("乳"))
+    val names = result.map { it.name }
+    assertTrue(names.contains("小麦"))
+    assertTrue(names.contains("卵"))
+    assertTrue(names.contains("乳"))
 
-        val mandatoryCount = result.count { it.type == AllergenType.MANDATORY }
-        assertEquals(3, mandatoryCount)
-    }
+    val mandatoryCount = result.count { it.type == AllergenType.MANDATORY }
+    assertEquals(3, mandatoryCount)
+  }
 
-    @Test
-    fun `detectAllergens finds recommended allergens`() {
-        val result = parser.detectAllergens("大豆、りんご果汁、ゼラチン")
+  @Test
+  fun `detectAllergens finds recommended allergens`() {
+    val result = parser.detectAllergens("大豆、りんご果汁、ゼラチン")
 
-        val names = result.map { it.name }
-        assertTrue(names.contains("大豆"))
-        assertTrue(names.contains("りんご"))
-        assertTrue(names.contains("ゼラチン"))
+    val names = result.map { it.name }
+    assertTrue(names.contains("大豆"))
+    assertTrue(names.contains("りんご"))
+    assertTrue(names.contains("ゼラチン"))
 
-        val recommendedCount = result.count { it.type == AllergenType.RECOMMENDED }
-        assertEquals(3, recommendedCount)
-    }
+    val recommendedCount = result.count { it.type == AllergenType.RECOMMENDED }
+    assertEquals(3, recommendedCount)
+  }
 
-    @Test
-    fun `parseIngredients extracts allergen sources from parentheses`() {
-        val result = parser.parseIngredients("しょうゆ（小麦・大豆を含む）、マヨネーズ（卵を含む）")
+  @Test
+  fun `parseIngredients extracts allergen sources from parentheses`() {
+    val result = parser.parseIngredients("しょうゆ（小麦・大豆を含む）、マヨネーズ（卵を含む）")
 
-        assertEquals(2, result.size)
-        assertEquals("しょうゆ", result[0].name)
-        assertTrue(result[0].allergenSources.contains("小麦"))
-        assertTrue(result[0].allergenSources.contains("大豆"))
-        assertEquals("マヨネーズ", result[1].name)
-        assertTrue(result[1].allergenSources.contains("卵"))
-    }
+    assertEquals(2, result.size)
+    assertEquals("しょうゆ", result[0].name)
+    assertTrue(result[0].allergenSources.contains("小麦"))
+    assertTrue(result[0].allergenSources.contains("大豆"))
+    assertEquals("マヨネーズ", result[1].name)
+    assertTrue(result[1].allergenSources.contains("卵"))
+  }
 
-    @Test
-    fun `parseAdditives classifies by category in parentheses`() {
-        val result = parser.parseAdditives("ソルビン酸K（保存料）、アスパルテーム（甘味料）、V.C（酸化防止剤）")
+  @Test
+  fun `parseAdditives classifies by category in parentheses`() {
+    val result = parser.parseAdditives("ソルビン酸K（保存料）、アスパルテーム（甘味料）、V.C（酸化防止剤）")
 
-        assertEquals(3, result.size)
-        assertEquals("保存料", result[0].category)
-        assertEquals("甘味料", result[1].category)
-        assertEquals("酸化防止剤", result[2].category)
-    }
+    assertEquals(3, result.size)
+    assertEquals("保存料", result[0].category)
+    assertEquals("甘味料", result[1].category)
+    assertEquals("酸化防止剤", result[2].category)
+  }
 
-    @Test
-    fun `parseAdditives without category defaults to その他`() {
-        val result = parser.parseAdditives("カラメル色素、pH調整剤")
+  @Test
+  fun `parseAdditives without category defaults to その他`() {
+    val result = parser.parseAdditives("カラメル色素、pH調整剤")
 
-        assertEquals(2, result.size)
-        assertEquals("その他", result[0].category)
-    }
+    assertEquals(2, result.size)
+    assertEquals("その他", result[0].category)
+  }
 
-    @Test
-    fun `parse complex real-world label`() {
-        val text =
-            "鶏肉（国産）、玉ねぎ、にんじん、じゃがいも、小麦粉（小麦を含む）、" +
-                "カレー粉、食塩、砂糖/調味料(アミノ酸等)、カラメル色素、酸味料、香料"
-        val result = parser.parse(text)
+  @Test
+  fun `parse complex real-world label`() {
+    val text = "鶏肉（国産）、玉ねぎ、にんじん、じゃがいも、小麦粉（小麦を含む）、" + "カレー粉、食塩、砂糖/調味料(アミノ酸等)、カラメル色素、酸味料、香料"
+    val result = parser.parse(text)
 
-        assertEquals(8, result.ingredients.size)
-        assertEquals(4, result.additives.size)
-        assertTrue(result.allergens.any { it.name == "小麦" })
-        assertTrue(result.allergens.any { it.name == "鶏肉" })
-    }
+    assertEquals(8, result.ingredients.size)
+    assertEquals(4, result.additives.size)
+    assertTrue(result.allergens.any { it.name == "小麦" })
+    assertTrue(result.allergens.any { it.name == "鶏肉" })
+  }
 
-    @Test
-    fun `parse preserves original text`() {
-        val text = "小麦粉、砂糖/ソルビン酸K（保存料）"
-        val result = parser.parse(text)
-        assertEquals(text, result.originalText)
-    }
+  @Test
+  fun `parse preserves original text`() {
+    val text = "小麦粉、砂糖/ソルビン酸K（保存料）"
+    val result = parser.parse(text)
+    assertEquals(text, result.originalText)
+  }
 }

--- a/src/test/kotlin/com/akaitigo/labeldecode/parser/StubAdditiveLookup.kt
+++ b/src/test/kotlin/com/akaitigo/labeldecode/parser/StubAdditiveLookup.kt
@@ -3,7 +3,7 @@ package com.akaitigo.labeldecode.parser
 import com.akaitigo.labeldecode.repository.AdditiveLookup
 
 class StubAdditiveLookup : AdditiveLookup {
-    override fun findCategoryByName(name: String): String? = null
+  override fun findCategoryByName(name: String): String? = null
 
-    override fun findCategoryByPartialName(name: String): String? = null
+  override fun findCategoryByPartialName(name: String): String? = null
 }


### PR DESCRIPTION
## Summary
- Makefile の `format` ターゲットが存在しない `formatKotlin` タスクを参照しており `make check` が常に失敗していた
- Spotless プラグイン (ktfmt) を追加し、Makefile を `spotlessApply` に修正
- 全 Kotlin ソースを ktfmt で統一フォーマット適用済み

## Test plan
- [x] `make format` が成功する
- [x] `./gradlew detekt` がパスする
- [x] `./gradlew test` が全テストパスする